### PR TITLE
Add TLS support for Cassandra connections

### DIFF
--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -23,7 +23,8 @@
                     {:replication {:class              "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
         cluster (if (sequential? cluster) cluster [cluster])
-        session (-> (assoc cassandra-options :contact-points cluster)
+        session (-> (assoc cassandra-options :contact-points cluster
+                                             :ssl? true)
                     (cond-> (and username password)
                       (assoc :credentials {:user     username
                                            :password password}))

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -27,6 +27,7 @@
         tls (or tls false)
         tls-options (or tls-options
                         ;; List of Mozilla's recommended suites for TLSv1.2(maximum supported in Java 8)
+                        ;; https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
                         {:cipher-suites ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
                          :keystore-path (-> (io/file (. (. System getProperties) (get "java.home")) "lib" "security" "cacerts") (.getPath))
                          :keystore-password "changeit"})

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -25,7 +25,7 @@
         cluster (if (sequential? cluster) cluster [cluster])
         tls (or tls false)
         tls-options (or tls-options
-                        ;; List of Mozilla's recommended suites for TLSv1.2(maximum support in Java 8)
+                        ;; List of Mozilla's recommended suites for TLSv1.2(maximum supported in Java 8)
                         {:cipher-suites ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
                          :keystore-path (str (. (. System getProperties) (get "java.home")) "/lib/security/cacerts")
                          :keystore-password "changeit"})

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -17,14 +17,15 @@
 (defn cassandra-store
   "Connect to a cassandra cluster, and use a specific keyspace.
    When the keyspace is not found, try creating it"
-  [{:keys [cassandra-options cluster keyspace hints repfactor username password ssl ssl-options] :as config}]
+  [{:keys [cassandra-options cluster keyspace hints repfactor username password tls tls-options] :as config}]
   (debug "building cassandra store for: " cluster keyspace hints)
   (let [hints   (or hints
                     {:replication {:class              "SimpleStrategy"
                                    :replication_factor (or repfactor 1)}})
         cluster (if (sequential? cluster) cluster [cluster])
-        ssl (or ssl false)
-        ssl-options (or ssl-options
+        tls (or tls false)
+        tls-options (or tls-options
+                        ;; List of Mozilla's recommended suites for TLSv1.2(maximum support in Java 8)
                         {:cipher-suites ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
                          :keystore-path (str (. (. System getProperties) (get "java.home")) "/lib/security/cacerts")
                          :keystore-password "changeit"})
@@ -32,8 +33,8 @@
                     (cond-> (and username password)
                       (assoc :credentials {:user     username
                                            :password password})
-                      (true? ssl) (assoc :ssl-options ssl-options))
-                    (assoc :ssl? ssl)
+                      (true? tls) (assoc :ssl-options tls-options))
+                    (assoc :ssl? tls)
                     (alia/cluster)
                     (alia/connect))]
     (try (alia/execute session (use-keyspace keyspace))

--- a/src/io/pithos/store.clj
+++ b/src/io/pithos/store.clj
@@ -3,7 +3,8 @@
   (:import com.datastax.driver.core.exceptions.InvalidQueryException)
   (:require [qbits.alia            :as alia]
             [qbits.hayt            :refer [use-keyspace create-keyspace with]]
-            [clojure.tools.logging :refer [debug]]))
+            [clojure.tools.logging :refer [debug]]
+            [clojure.java.io       :as io]))
 
 (defprotocol Convergeable
   (converge! [this]))
@@ -27,7 +28,7 @@
         tls-options (or tls-options
                         ;; List of Mozilla's recommended suites for TLSv1.2(maximum supported in Java 8)
                         {:cipher-suites ["TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"]
-                         :keystore-path (str (. (. System getProperties) (get "java.home")) "/lib/security/cacerts")
+                         :keystore-path (-> (io/file (. (. System getProperties) (get "java.home")) "lib" "security" "cacerts") (.getPath))
                          :keystore-password "changeit"})
         session (-> (assoc cassandra-options :contact-points cluster)
                     (cond-> (and username password)


### PR DESCRIPTION
By default sets cipher suites from Mozilla's recommendation list for
TLSv1.2(maximum supported version in Java 8).
https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29